### PR TITLE
Remove duplicated call for AccessMethods.php

### DIFF
--- a/HttpClient.php
+++ b/HttpClient.php
@@ -1,12 +1,6 @@
 <?php
 
 require_once('AccessMethods.php');
-
-/**
- * Http client used to perform requests on Eventbrite API.
- */
-
-require_once('AccessMethods.php');
 /**
  * Http client used to perform requests on Eventbrite API.
  */


### PR DESCRIPTION
There's a duplicated call for `AccessMethods.php` on `HttpClient.php`, PHP would ignore it, but by removing it, we'll save a server request.