### PR TITLE
Fixes "You passed a request body that was not in JSON format" when do…

### DIFF
--- a/HttpClient.php
+++ b/HttpClient.php
@@ -47,10 +47,13 @@ class HttpClient extends AccessMethods
             'http'=>array(
                 'method'=>$httpMethod,
                 'header'=>"content-type: application/json\r\n",
-                'content'=>$data,
                 'ignore_errors'=>true
             )
         );
+
+        if ($httpMethod == 'POST') {
+            $options['http']['content'] = $data;
+        }
 
         $url = self::EVENTBRITE_APIv3_BASE . $path . '?token=' . $this->token;
 


### PR DESCRIPTION
Fixes "You passed a request body that was not in JSON format" when doing GET requests in some endpoits. References issue#7 https://github.com/eventbrite/eventbrite-sdk-php/issues/7