### PR TITLE
Update and rename README.md to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ You can also specify API endpoints manually:
 Contributing
 ------------
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/eventbrite/eventbrite-sdk-python.
+Bug reports and pull requests are welcome on GitHub at https://github.com/eventbrite/eventbrite-sdk-php.
 
 
 License


### PR DESCRIPTION
Change to .rst extension to match markup
Fix typo in URL to point to correct SDK